### PR TITLE
Add uri schemes to transit transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-## Change Log
+# Change Log
 
-### master (unreleased)
+## master (unreleased)
 
-#### Changes
+### Changes
 
 * Adds uri scheme to transit transports.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
-# Change Log
+## Change Log
 
-## master
+### master (unreleased)
+
+#### Changes
+
+* Adds uri scheme to transit transports.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Afterwards you can start the server like this:
 You can also start it via the built-in nREPL CLI:
 
 ``` shell
-$ clj -R:nrepl -m nrepl.cmdline -t fastlane.core/transit+json
+# Change the nREPL and fastlane versions to your preferences
+$ clj -Sdeps '{:deps {nrepl {:mvn/version "0.6.0-SNAPSHOT"} nrepl/fastlane {:mvn/version "0.2.0-SNAPSHOT"}}}' -m nrepl.cmdline --transport fastlane.core/transit+json
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -35,12 +35,53 @@ Afterwards you can start the server like this:
 (server/start-server :port 12345 :transport-fn fastlane/transit+json)
 ```
 
-You can also start it via the built-in nREPL CLI:
+You can also start it via the built-in nREPL CLI with the following options:
+
+### Using deps inline with `clj`
 
 ``` shell
-# Change the nREPL and fastlane versions to your preferences
-$ clj -Sdeps '{:deps {nrepl {:mvn/version "0.6.0-SNAPSHOT"} nrepl/fastlane {:mvn/version "0.2.0-SNAPSHOT"}}}' -m nrepl.cmdline --transport fastlane.core/transit+json
+$ clj -Sdeps '{:deps {nrepl {:mvn/version "0.5.3"} nrepl/fastlane {:mvn/version "0.2.0-SNAPSHOT"}}}' -m nrepl.cmdline --transport fastlane.core/transit+json
 ```
+
+### Creating a `nrepl` profile at `deps.edn` with `clj`
+
+``` shell
+$ cat deps.edn
+{:aliases
+ {:nrepl {:extra-deps {nrepl {:mvn/version "0.5.3"}
+                       nrepl/fastlane {:mvn/version "0.2.0-SNAPSHOT"}}}}}
+$ clj -R:nrepl -m nrepl.cmdline --transport fastlane.core/transit+json
+```
+
+### Creating a `nrepl` profile at `deps.edn` with `clj` using `nrepl` configuration file (`.nrepl.edn`)
+
+``` shell
+$ cat deps.edn
+{:aliases
+ {:nrepl {:extra-deps {nrepl {:mvn/version "0.5.3"}
+                       nrepl/fastlane {:mvn/version "0.2.0-SNAPSHOT"}}}}}
+$ cat .nrepl.edn
+{:transport fastlane.core/transit+json}
+$ clj -R:nrepl -m nrepl.cmdline
+```
+
+### Using `lein` for headless REPL with a `nrepl` configuration file
+
+``` shell
+# With `[nrepl/fastlane "0.2.0-SNAPSHOT"]` at your `project.clj`
+# and configuration at .nrepl.edn
+$ cat .nrepl.edn
+{:transport fastlane.core/transit+json}
+$ lein repl :headless
+# It should start with transit+json transport
+```
+
+### Using `lein` for interactive REPL (in construction...)
+
+``` shell
+# TODO
+```
+
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject nrepl/fastlane "0.1.0"
+(defproject nrepl/fastlane "0.2.0-SNAPSHOT"
   :description "Transit transports for nREPL."
   :url "https://github.com/nrepl/fastlane"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/nrepl/fastlane"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [nrepl "0.5.0"]
+                 [nrepl "0.5.3"]
                  [com.cognitect/transit-clj "0.8.313"]]
 
   :aliases {"test-all" ["with-profile" "+1.8:+1.9" "test"]}

--- a/src/fastlane/core.clj
+++ b/src/fastlane/core.clj
@@ -3,7 +3,7 @@
    [clojure.java.io :as io]
    [cognitect.transit :as transit]
    [nrepl.core :as nrepl]
-   [nrepl.transport :refer [fn-transport]])
+   [nrepl.transport :as transport :refer [fn-transport]])
   (:import
    [java.io EOFException PushbackInputStream]
    [java.net Socket SocketException]))
@@ -97,6 +97,8 @@
                                        :port 7888}
                                       (socket-info uri)))))
 
+(defmethod transport/uri-scheme #'transit+msgpack [_] "transit+msgpack")
+
 (defmethod nrepl/url-connect "transit+json"
   [uri]
   (apply nrepl/connect (mapcat identity
@@ -104,9 +106,13 @@
                                        :port 7888}
                                       (socket-info uri)))))
 
+(defmethod transport/uri-scheme #'transit+json [_] "transit+json")
+
 (defmethod nrepl/url-connect "transit+json-verbose"
   [uri]
   (apply nrepl/connect (mapcat identity
                                (merge {:transport-fn transit+json-verbose
                                        :port 7888}
                                       (socket-info uri)))))
+
+(defmethod transport/uri-scheme #'transit+json-verbose [_] "transit+json-verbose")

--- a/test/fastlane/core_test.clj
+++ b/test/fastlane/core_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [fastlane.core :as fastlane]
             [nrepl.core :as nrepl]
-            [nrepl.server :as server]))
+            [nrepl.server :as server]
+            [nrepl.transport :as transport]))
 
 (def transport-fn->protocol
   "Add your transport-fn var here so it can be tested"
@@ -34,3 +35,8 @@
                  (nrepl/message {:op "eval" :code "(+ 2 3)"})
                  nrepl/response-values)))
          [5])))
+
+(deftest uri-scheme
+  (let [expected (transport-fn->protocol *transport-fn*)]
+    (is (= expected
+           (transport/uri-scheme *transport-fn*)))))


### PR DESCRIPTION
If uri scheme is not set to a transport, it will
appear as `unknown` when starting nREPL with the
command line.